### PR TITLE
Gate license actions on active status and surface current VRK

### DIFF
--- a/js/apps/admin-ui/src/components/tide-licensing-tab/TideLicenseHistory.tsx
+++ b/js/apps/admin-ui/src/components/tide-licensing-tab/TideLicenseHistory.tsx
@@ -18,7 +18,6 @@ import {
   EmptyStateHeader,
   EmptyStateBody,
   Button,
-  Spinner,
   AlertVariant,
 } from "@patternfly/react-core";
 import { InfoCircleIcon } from "@patternfly/react-icons";
@@ -134,7 +133,7 @@ function parseLicenseData(raw: any): null | { gVRK?: string; [k: string]: any } 
 }
 
 const isActionableStatus = (status: string) =>
-  /^(upcoming\s*renewal|active)$/i.test((status || "").trim());
+  /^active$/i.test((status || "").trim());
 
 export const TideLicenseHistory: React.FC<TideLicenseHistoryProps> = ({
   licenseList,
@@ -172,31 +171,6 @@ export const TideLicenseHistory: React.FC<TideLicenseHistoryProps> = ({
 
   const setRowLoading = (key: string, v: boolean) =>
     setLoading((prev) => ({ ...prev, [key]: v }));
-
-  // SIGN
-  const handleSign = async (row: (typeof rows)[number]) => {
-    try {
-      setRowLoading(row.key, true);
-      const parsed = parseLicenseData(row.original.licenseData);
-      const gvrk = parsed?.gVRK?.toString?.().trim();
-
-      const message: string | void = await adminClient.tideAdmin.licenseProvider({
-        gvrk, // optional, send if present
-      });
-
-      addAlert(
-        t(
-          "LicensingSigningReviewCreated",
-          message || "Request to sign new license created"
-        ),
-        AlertVariant.success
-      );
-    } catch (error: any) {
-      addError("signingNewLicenseError", error);
-    } finally {
-      setRowLoading(row.key, false);
-    }
-  };
 
   // SWITCH
   const handleSwitch = async (row: (typeof rows)[number]) => {
@@ -284,7 +258,7 @@ export const TideLicenseHistory: React.FC<TideLicenseHistoryProps> = ({
             <Th width={40}>License</Th>
             <Th>Status</Th>
             <Th>
-              Date{" "}
+              Expires{" "}
               <Tooltip
                 content={
                   <>
@@ -345,7 +319,7 @@ export const TideLicenseHistory: React.FC<TideLicenseHistoryProps> = ({
                   </Label>
                 </Td>
 
-                <Td dataLabel="Date">
+                <Td dataLabel="Expires">
                   {r.hasValidDate ? (
                     <Tooltip
                       content={
@@ -362,7 +336,7 @@ export const TideLicenseHistory: React.FC<TideLicenseHistoryProps> = ({
                         </>
                       }
                     >
-                      <span aria-label={`Local date ${r.local}`}>
+                      <span aria-label={`Expires ${r.local}`}>
                         {r.local}{" "}
                         <span
                           style={{ opacity: 0.75, fontSize: "0.85em", marginLeft: 6 }}
@@ -382,20 +356,11 @@ export const TideLicenseHistory: React.FC<TideLicenseHistoryProps> = ({
                     <div
                       style={{
                         display: "grid",
-                        gridTemplateColumns: "1fr 1fr",
+                        gridTemplateColumns: "1fr",
                         gap: 8,
-                        minWidth: 180,
+                        minWidth: 90,
                       }}
                     >
-                      <Button
-                        variant="primary"
-                        onClick={() => handleSign(r)}
-                        aria-label="Sign license"
-                        style={{ width: "100%" }}
-                        isDisabled={isBusy}
-                      >
-                        {isBusy ? <Spinner size="sm" /> : "Sign"}
-                      </Button>
                       <Button
                         variant="secondary"
                         onClick={() => handleSwitch(r)}

--- a/js/apps/admin-ui/src/components/tide-licensing-tab/TideLicensingTab.tsx
+++ b/js/apps/admin-ui/src/components/tide-licensing-tab/TideLicensingTab.tsx
@@ -492,6 +492,23 @@ export const TideLicensingTab: FC<TideLicensingTabProps> = ({ refreshCallback })
                   </FormGroup>
 
                   <FormGroup
+                    label={t("Current VRK")}
+                    labelIcon={
+                      <HelpItem
+                        helpText={"The live active VRK currently in use by this license."}
+                        fieldLabelId={"LicenseCurrentVRK"}
+                      />
+                    }
+                    fieldId="license-current-vrk"
+                  >
+                    {hasValue(watchConfigGVRK) ? (
+                      <ClipboardCopy isCode isReadOnly>{watchConfigGVRK}</ClipboardCopy>
+                    ) : (
+                      <span style={{ opacity: 0.7 }}>—</span>
+                    )}
+                  </FormGroup>
+
+                  <FormGroup
                     label={t("Expiry Date")}
                     labelIcon={
                       <HelpItem

--- a/js/libs/keycloak-admin-client/src/resources/tideProvider.ts
+++ b/js/libs/keycloak-admin-client/src/resources/tideProvider.ts
@@ -296,12 +296,6 @@ export class TideProvider extends Resource<{ realm?: string }> {
         method: "POST",
         path: "/ragnarok/trigger-offboarding",
     });
-    /* # TIDECLOAK IMPLEMENTATION */
-    public licenseProvider = this.makeRequest<{ gvrk?: string }, string>({
-        method: "POST",
-        path: "/tideAdminResources/trigger-license-signing",
-        queryParamKeys: ["gvrk"],
-    });
 
     constructor(client: KeycloakAdminClient) {
         super(client, {


### PR DESCRIPTION
- Restrict row actions to active licenses only; upcoming-renewal rows are no longer actionable, removing the premature-rotation path
- Drop the standalone Sign action (and its admin-client licenseProvider call) so Switch is the sole license action surface
- Display the live Current VRK in the license details panel and relabel the history Date column to Expires for clarity

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
