### PR TITLE
Fix the licensing capacity slider: correct scale, package boxes, and new-tab redirects

### DIFF
--- a/js/apps/admin-ui/src/components/tide-licensing-tab/TideLicensingTab.tsx
+++ b/js/apps/admin-ui/src/components/tide-licensing-tab/TideLicensingTab.tsx
@@ -66,6 +66,29 @@ function readRedirectUrl(response: unknown): string {
 // Any other body is the Stripe checkout URL, returned with HTTP 303.
 const VENDOR_KEY_CREATED = "CREATED";
 const VENDOR_KEY_NEEDS_PAYMENT = "NEED_PAYMENT";
+/**
+ * Run a vendor redirect call and land its hosted page in a new tab.
+ *
+ * The tab is opened BEFORE the request is issued: a `window.open` after an
+ * await has lost user activation and the browser blocks it with no error. A
+ * blocked open returns null, so that case falls back to this tab rather than
+ * leaving the operator on a button that appears to do nothing.
+ */
+async function openRedirectInNewTab(
+  request: () => Promise<unknown>,
+): Promise<void> {
+  // Not "noopener": that makes window.open return null and we need the handle.
+  const tab = window.open("", "_blank");
+  if (tab) tab.opener = null;
+  try {
+    const url = readRedirectUrl(await request());
+    if (tab) tab.location.replace(url);
+    else window.location.href = url;
+  } catch (error) {
+    tab?.close();
+    throw error;
+  }
+}
 
 export const TideLicensingTab: FC<TideLicensingTabProps> = () => {
   const { t } = useTranslation();
@@ -257,7 +280,6 @@ export const TideLicensingTab: FC<TideLicensingTabProps> = () => {
         }
         // license renewed
 
-
         if (signSettingsRequired) {
           // Payment has landed — resume vendor key creation. No licensing tier
           // is sent: the backend already has it from the initial call.
@@ -269,7 +291,10 @@ export const TideLicensingTab: FC<TideLicensingTabProps> = () => {
             // genuinely haven't paid, the retry hands back a Stripe URL.
             setIsLoading(false);
             await refresh();
-            addAlert(t("Awaiting payment confirmation, please try again shortly."), AlertVariant.warning);
+            addAlert(
+              t("Awaiting payment confirmation, please try again shortly."),
+              AlertVariant.warning,
+            );
             return;
           }
 
@@ -410,13 +435,15 @@ export const TideLicensingTab: FC<TideLicensingTabProps> = () => {
         // Awaiting payment, but the backend has no checkout URL to send us to.
         setIsLoading(false);
         await refresh();
-        addAlert(t("Awaiting payment confirmation, please try again shortly."), AlertVariant.warning);
+        addAlert(
+          t("Awaiting payment confirmation, please try again shortly."),
+          AlertVariant.warning,
+        );
         return;
       }
 
       // Anything else is the Stripe checkout URL (HTTP 303).
       window.location.href = result;
-
     } catch (err) {
       await adminClient.tideAdmin.reAddTideKey();
       setIsLoading(false);

--- a/js/apps/admin-ui/src/components/tide-licensing-tab/TideLicensingTab.tsx
+++ b/js/apps/admin-ui/src/components/tide-licensing-tab/TideLicensingTab.tsx
@@ -536,10 +536,11 @@ export const TideLicensingTab: FC<TideLicensingTabProps> = () => {
    */
   const handleAddPaymentMethod = async () => {
     try {
-      const form = new FormData();
-      form.append("returnUrl", window.location.href);
-      const response = await adminClient.tideAdmin.addPaymentMethod(form);
-      window.location.href = readRedirectUrl(response);
+      await openRedirectInNewTab(() => {
+        const form = new FormData();
+        form.append("returnUrl", window.location.href);
+        return adminClient.tideAdmin.addPaymentMethod(form);
+      });
     } catch (error) {
       addError("Could not start payment method collection", error);
     }
@@ -550,11 +551,11 @@ export const TideLicensingTab: FC<TideLicensingTabProps> = () => {
       const redirectUrl = window.location.href.endsWith("/")
         ? window.location.href.slice(0, -1)
         : window.location.href;
-      const form = new FormData();
-      form.append("redirectUrl", redirectUrl);
-      const response =
-        await adminClient.tideAdmin.createCustomerPortalSession(form);
-      window.location.href = readRedirectUrl(response);
+      await openRedirectInNewTab(() => {
+        const form = new FormData();
+        form.append("redirectUrl", redirectUrl);
+        return adminClient.tideAdmin.createCustomerPortalSession(form);
+      });
     } catch (error) {
       // Previously uncaught: a portal session the payer refused left the
       // button looking inert with nothing said.

--- a/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/EnterprisePricing.tsx
+++ b/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/EnterprisePricing.tsx
@@ -38,6 +38,7 @@ import {
 import { FC, ReactNode, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { capacityRange, type CapacityRange } from "./capacity";
+import styles from "./package-stops.module.css";
 import {
   formatCount,
   formatInterval,
@@ -314,6 +315,20 @@ const CapacityChooser: FC<ChooserProps> = ({
         />
       )}
 
+      {isSingleOption ? null : (
+        <>
+          <Divider className="pf-v5-u-my-md" />
+          <PackageStops
+            packages={packages}
+            freePlan={freePlan}
+            quote={isFree ? undefined : quote}
+            isFree={isFree}
+            users={users}
+            onUsersChange={onUsersChange}
+          />
+        </>
+      )}
+
       {!hasMultiplePackageSizes ? (
         <TextContent data-testid="pricing-single-package">
           <Text component="small">
@@ -499,6 +514,114 @@ const CapacityChooser: FC<ChooserProps> = ({
         <Skeleton height="12rem" screenreaderText={t("Loading pricing")} />
       )}
     </div>
+  );
+};
+
+/**
+ * The package stops under the capacity slider.
+ *
+ * The slider moved and the total changed, but nothing on screen tied the two
+ * together: the capacity below it ("Up to 200 users") is the SERVER's answer,
+ * not the number under the thumb, so the two read as unrelated. Here every
+ * buyable package is a box, and the boxes the current quote is actually made of
+ * are highlighted — dragging the slider lights up what is being bought, and the
+ * itemised total below is then just the same boxes written out.
+ *
+ * The highlight comes from the quote's line items. Nothing here decides which
+ * packages cover a capacity; that stays on the server with the Stripe
+ * credentials, like every other figure on this card.
+ */
+const PackageStops: FC<{
+  packages: PricingTier[];
+  freePlan: PricingTier | null;
+  /** The current quote, or undefined while the free plan is the selection. */
+  quote: PricingQuote | undefined;
+  isFree: boolean;
+  users: number;
+  onUsersChange: (users: number) => void;
+}> = ({ packages, freePlan, quote, isFree, users, onUsersChange }) => {
+  const { t } = useTranslation();
+  const lines = new Map(
+    quote?.lineItems.map((line) => [line.priceId, line] as const),
+  );
+
+  return (
+    <div>
+      <TextContent className="pf-v5-u-mb-sm">
+        <Text component="small">
+          {isFree
+            ? t("Covered by the free plan.")
+            : quote
+              ? t("Covering your {{users}} users with:", {
+                  users: formatCount(users),
+                })
+              : t("Available packages")}
+        </Text>
+      </TextContent>
+
+      <div className={styles.stops} data-testid="pricing-package-stops">
+        {freePlan ? (
+          <PackageStop
+            label={formatCount(freePlan.userLimit)}
+            detail={t("Free plan")}
+            ariaLabel={t("Free plan, up to {{limit}} users", {
+              limit: formatCount(freePlan.userLimit),
+            })}
+            isSelected={isFree}
+            onSelect={() => onUsersChange(freePlan.userLimit)}
+          />
+        ) : null}
+
+        {packages.map((pkg) => {
+          const line = lines.get(pkg.priceId);
+          const price = formatMoney(pkg.unitAmount, pkg.currency);
+          return (
+            <PackageStop
+              key={pkg.priceId}
+              label={formatCount(pkg.userLimit)}
+              // How many of this package the quote takes, when it takes more
+              // than one — otherwise the box just states what the package costs.
+              detail={
+                line && line.packages > 1
+                  ? `${line.packages} \u00d7 ${price}`
+                  : price
+              }
+              ariaLabel={t("{{size}}-user package", {
+                size: formatCount(pkg.userLimit),
+              })}
+              isSelected={line !== undefined}
+              onSelect={() => onUsersChange(pkg.userLimit)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const PackageStop: FC<{
+  label: string;
+  detail: string;
+  ariaLabel: string;
+  isSelected: boolean;
+  onSelect: () => void;
+}> = ({ label, detail, ariaLabel, isSelected, onSelect }) => {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={isSelected}
+      aria-label={ariaLabel}
+      className={isSelected ? `${styles.stop} ${styles.selected}` : styles.stop}
+      data-testid="pricing-package-stop"
+      data-selected={isSelected}
+    >
+      <span className={styles.size}>
+        {label} {t("users")}
+      </span>
+      <span className={styles.detail}>{detail}</span>
+    </button>
   );
 };
 

--- a/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/EnterprisePricing.tsx
+++ b/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/EnterprisePricing.tsx
@@ -35,11 +35,18 @@ import {
   TextContent,
   Title,
 } from "@patternfly/react-core";
-import { FC, ReactNode, useEffect, useState } from "react";
+import { FC, ReactNode, useEffect, useId, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { capacityRange, type CapacityRange } from "./capacity";
+import {
+  capacityRange,
+  capacityStops,
+  positionToUsers,
+  usersToPosition,
+  type CapacityRange,
+} from "./capacity";
 import styles from "./package-stops.module.css";
 import {
+  formatCompactCount,
   formatCount,
   formatInterval,
   formatMoney,
@@ -213,6 +220,7 @@ const CapacityChooser: FC<ChooserProps> = ({
   isCtaDisabled,
 }) => {
   const { t } = useTranslation();
+  const capacityLiveId = useId();
 
   // With a single package size in Stripe, min === max, so the packages give no
   // range to slide over. Capacity still varies — you can buy several of the one
@@ -231,19 +239,30 @@ const CapacityChooser: FC<ChooserProps> = ({
   const isSingleOption = packages.length + (freePlan ? 1 : 0) <= 1;
 
   const hasMultiplePackageSizes = range.max > range.min;
-  const sliderMax = hasMultiplePackageSizes
-    ? range.max
-    : range.min * MULTI_BUY_STOPS;
-  // Every whole user is selectable, not just package boundaries. Stepping in
-  // package sizes meant 150 could not be expressed at all: it jumped 100 -> 200,
-  // and the operator was shown a capacity they never asked for. The server
-  // answers any count with the cheapest packages covering it, so 150 quotes one
-  // 100-user package and reads as "add 100 for $50".
-  const sliderStep = 1;
 
-  // A count typed above the track's top is still quotable (packages combine);
-  // it just pins the thumb at the end.
-  const sliderValue = Math.min(Math.max(users, range.min), sliderMax);
+  // One package size gives nothing to slide between, so the track spans
+  // multiples of it. Those are real boundaries (you buy several of the one
+  // package) rather than an invented scale.
+  const packageSizes = capacityStops(packages, freePlan?.userLimit);
+  const stops =
+    packageSizes.length > 1
+      ? packageSizes
+      : Array.from(
+          { length: MULTI_BUY_STOPS },
+          (_, i) => (packageSizes[0] ?? range.min) * (i + 1),
+        );
+
+  // The track runs in POSITION space, not user counts: see capacity.ts. This is
+  // also what suppresses two PatternFly defects that only fire without
+  // customSteps — a thumb positioned by raw value, and a per-render loop over
+  // every step from min to max.
+  const lastStop = stops.length - 1;
+  const sliderPosition = usersToPosition(users, stops);
+  const customSteps = stops.map((size, index) => ({
+    value: index,
+    label: formatCompactCount(size),
+  }));
+
   const overshoot = quote ? quote.includedUsers - quote.requestedUsers : 0;
 
   // The free plan is kept alongside whatever is bought, so the total is
@@ -291,42 +310,55 @@ const CapacityChooser: FC<ChooserProps> = ({
       )}
 
       {isSingleOption ? null : (
-        <Slider
-          min={range.min}
-          max={sliderMax}
-          step={sliderStep}
-          value={sliderValue}
-          inputValue={users}
-          isInputVisible
-          inputLabel={t("users")}
-          inputAriaLabel={t("Exact number of users")}
-          showBoundaries
-          // PatternFly reports the typed value as `inputValue` and the dragged
-          // one as `value`. Neither is snapped to a package size: the operator
-          // states how many users they have and the server answers with the
-          // cheapest packages covering it. Snapping ran to NEAREST, so every
-          // count from 101 to 149 rounded down to 100 and landed back inside
-          // the free plan, and asking for one user more than the free plan
-          // appeared to change nothing.
-          onChange={(_event, value, inputValue) =>
-            onUsersChange(Math.max(1, inputValue ?? value))
-          }
-          data-testid="pricing-slider"
-        />
+        <>
+          <Slider
+            min={0}
+            max={lastStop}
+            step={1}
+            value={sliderPosition}
+            customSteps={customSteps}
+            areCustomStepsContinuous
+            inputValue={users}
+            isInputVisible
+            inputLabel={t("users")}
+            inputAriaLabel={t("Exact number of users")}
+            aria-describedby={capacityLiveId}
+            // PatternFly reports the typed count as `inputValue` and the dragged
+            // POSITION as `value`, so only the drag path is converted. Neither
+            // is snapped to a package size: the operator states how many users
+            // they have and the server answers with the cheapest packages
+            // covering it.
+            onChange={(_event, value, inputValue) =>
+              onUsersChange(
+                Math.max(1, inputValue ?? positionToUsers(value, stops)),
+              )
+            }
+            data-testid="pricing-slider"
+          />
+          {/* The thumb's own aria-valuenow is a position, and PatternFly offers
+              no way to override it, so the real count is announced here. */}
+          <span
+            id={capacityLiveId}
+            className="pf-v5-screen-reader"
+            aria-live="polite"
+          >
+            {t("{{count}} users", {
+              count: users,
+              replace: { count: formatCount(users) },
+            })}
+          </span>
+        </>
       )}
 
       {isSingleOption ? null : (
-        <>
-          <Divider className="pf-v5-u-my-md" />
-          <PackageStops
-            packages={packages}
-            freePlan={freePlan}
-            quote={isFree ? undefined : quote}
-            isFree={isFree}
-            users={users}
-            onUsersChange={onUsersChange}
-          />
-        </>
+        <PackageStops
+          packages={packages}
+          freePlan={freePlan}
+          quote={isFree ? undefined : quote}
+          isFree={isFree}
+          users={users}
+          onUsersChange={onUsersChange}
+        />
       )}
 
       {!hasMultiplePackageSizes ? (

--- a/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/capacity.ts
+++ b/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/capacity.ts
@@ -53,3 +53,48 @@ function gcd(a: number, b: number): number {
   }
   return x;
 }
+
+/**
+ * The package sizes the track is built from: ascending, de-duplicated, and
+ * including the free plan so the axis reads "free up to here, priced above".
+ */
+export function capacityStops(
+  tiers: PricingTier[],
+  freeLimit?: number,
+): number[] {
+  const limits = tiers.map((t) => t.userLimit);
+  if (freeLimit && freeLimit > 0) limits.push(freeLimit);
+  return [...new Set(limits.filter((n) => Number.isFinite(n) && n > 0))].sort(
+    (a, b) => a - b,
+  );
+}
+
+/**
+ * POSITION SPACE. Package sizes span orders of magnitude, so a track that maps
+ * value to position linearly puts every small package in the leftmost few
+ * percent and makes the label under the thumb a lie. Instead each adjacent pair
+ * of package sizes owns one equal segment of the track, interpolated linearly
+ * inside it: position `i` is exactly `stops[i]`, and every stop is evenly
+ * spaced, so a thumb under a label really does mean that package size.
+ */
+export function positionToUsers(position: number, stops: number[]): number {
+  if (stops.length === 0) return 0;
+  const last = stops.length - 1;
+  if (last === 0) return stops[0]!;
+  const clamped = Math.min(Math.max(position, 0), last);
+  const index = Math.min(Math.floor(clamped), last - 1);
+  const fraction = clamped - index;
+  const from = stops[index]!;
+  return Math.round(from + (stops[index + 1]! - from) * fraction);
+}
+
+/** Inverse of {@link positionToUsers}; counts outside the track pin to an end. */
+export function usersToPosition(users: number, stops: number[]): number {
+  const last = stops.length - 1;
+  if (last <= 0) return 0;
+  if (users <= stops[0]!) return 0;
+  if (users >= stops[last]!) return last;
+  const next = stops.findIndex((stop) => stop > users);
+  const from = stops[next - 1]!;
+  return next - 1 + (users - from) / (stops[next]! - from);
+}

--- a/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/format.ts
+++ b/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/format.ts
@@ -100,6 +100,17 @@ export function formatCount(value: number): string {
 }
 
 /**
+ * A user count abbreviated for the slider axis: `200000` -> `"200K"`. Full
+ * counts are too wide to sit side by side under the track.
+ */
+export function formatCompactCount(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+/**
  * Billing interval as a suffix: `"month"` -> `"/ month"`. Passed through from
  * Stripe rather than assumed, so a yearly Price renders correctly too.
  */

--- a/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/package-stops.module.css
+++ b/js/apps/admin-ui/src/components/tide-licensing-tab/pricing/package-stops.module.css
@@ -1,0 +1,53 @@
+/*
+ * The package stops under the capacity slider: one box per buyable package,
+ * with the boxes the current quote is actually made of lit up. The row is the
+ * slider's legend, so it has to read as "these are the sizes, and THESE are the
+ * ones you are getting" at a glance — a row of bare numbers did not.
+ */
+.stops {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--pf-v5-global--spacer--sm);
+}
+
+.stop {
+  flex: 1 1 7rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--pf-v5-global--spacer--xs);
+  padding: var(--pf-v5-global--spacer--sm);
+  border: 1px solid var(--pf-v5-global--BorderColor--100);
+  border-radius: var(--pf-v5-global--BorderRadius--sm);
+  background-color: var(--pf-v5-global--BackgroundColor--100);
+  color: var(--pf-v5-global--Color--200);
+  cursor: pointer;
+  text-align: center;
+}
+
+.stop:hover {
+  border-color: var(--pf-v5-global--primary-color--100);
+}
+
+/*
+ * The selected emphasis is drawn with an inset shadow rather than a thicker
+ * border so lighting a box up does not resize it and shuffle the row.
+ */
+.selected {
+  border-color: var(--pf-v5-global--primary-color--100);
+  box-shadow: inset 0 0 0 1px var(--pf-v5-global--primary-color--100);
+  background-color: var(--pf-v5-global--palette--blue-50);
+  color: var(--pf-v5-global--Color--100);
+}
+
+.size {
+  font-weight: var(--pf-v5-global--FontWeight--bold);
+  font-size: var(--pf-v5-global--FontSize--md);
+  color: var(--pf-v5-global--Color--100);
+  font-variant-numeric: tabular-nums;
+}
+
+.detail {
+  font-size: var(--pf-v5-global--FontSize--xs);
+  font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
Fixes the Enterprise capacity slider on the licensing tab, which mispositioned the thumb and never tied the slider to the package it was buying.

## Position-domain slider

Package sizes span orders of magnitude (e.g. 500 and 200,000 on the same axis). The slider mapped value to position linearly, so every small package collapsed into the leftmost few percent of the track and the number label under the thumb meant nothing.

The track now runs in position space: each adjacent pair of package sizes owns one equal segment of the rail, interpolated linearly inside it. Position `i` is exactly package size `stops[i]`, so a thumb under the "500" label genuinely means 500, and the axis, the package boxes and the thumb all agree. Two small pure functions (`usersToPosition` / `positionToUsers`, verified lossless inverses) do the mapping; the free-text input, the blur/Enter commit, clamping, and the quote request all still operate in real user counts, so no pricing logic moved.

Driving the slider through PatternFly's `customSteps` also disables two PatternFly v5.4.14 defects that only fire without custom steps:
- the thumb positioned by raw value with a `%` suffix (throws the thumb off the rail for any value above ~100), and
- a per-render loop over every step from min to max, which was ~199,901 iterations per frame at step 1 over a 200,000-user range.

The single-package track now spans real multiples of that package rather than an invented ten-fold scale.

## Quote-highlighted package boxes

A row of package boxes sits under the axis, each showing its size and price. The boxes that make up the current server quote are highlighted from the quote's line items, so dragging the slider lights up exactly what is being bought, and the itemised total below is the same boxes written out.

## New-tab Stripe redirects

The three Stripe redirects on the tab (checkout, add-payment-method, customer portal) now open their hosted page in a new tab via one shared helper. The tab is opened synchronously in the click handler before the request is issued, since a `window.open` after an `await` is silently blocked; a blocked open falls back to same-tab navigation, and existing error reporting is preserved on every path.

## Notes

- Mirrors the equivalent fixes already made in the tide-console SPA.
- No backend change required.
- Screen-reader handling: the axis labels are decorative (PatternFly marks them `aria-hidden`); the thumb's `aria-valuenow` becomes a position, so the real user count is announced through a visually hidden live region.
